### PR TITLE
Fix the style of unordered list inside ordered list

### DIFF
--- a/styles/typography.less
+++ b/styles/typography.less
@@ -36,7 +36,7 @@ ol{
     margin-left: 0;
     padding-right: 0;
     list-style-type: none;
-    li {
+    > li {
         counter-increment: step-counter;
         &::before {
             content: counter(step-counter);


### PR DESCRIPTION
One character missing and it was breaking the style when we try to have an unordered list nested in a ordered list.
This should fix your pb @Delphineray. ;)