### PR TITLE
Fix typo sur identifier attribute type warning

### DIFF
--- a/content/md/what-is/what-is-an-attribute.md
+++ b/content/md/what-is/what-is-an-attribute.md
@@ -29,7 +29,7 @@ The only mandatory attribute is the **Identifier attribute type**. You first nee
 :::
 
 :::warning
-You can only have only one **identifier attribute type** in your PIM.
+You can only have one **identifier attribute type** in your PIM.
 :::
 
 :::warning


### PR DESCRIPTION
I had written "only" twice..