### PR TITLE
Update manage-your-attributes.md

### DIFF
--- a/content/md/first-steps/manage-your-attributes.md
+++ b/content/md/first-steps/manage-your-attributes.md
@@ -92,7 +92,8 @@ The attribute is now created, you **can add a translation for each enabled local
 
 ::: warning
 Please note that the **following attribute codes cannot be used** in Akeneo PIM:    
-`id`, `associationTypes`, `category`, `categories`, `categoryId`, `completeness`, `enabled`, `family`, `groups`, `associations`, `products`, `scope`, `treeId`, `values`, `label`, `parent`
+`id`, `associationTypes`, `category`, `categories`, `categoryId`, `completeness`, `enabled`, `family`, `Family`, `groups`, `associations`, `products`, `scope`, `treeId`, `values`, `label`, `parent`.    
+We strongly recommend you to do not use any of these codes even if the casse is different, for instance `Id`, `Groups`.
 :::
 
 ::: warning

--- a/content/md/first-steps/manage-your-attributes.md
+++ b/content/md/first-steps/manage-your-attributes.md
@@ -93,7 +93,7 @@ The attribute is now created, you **can add a translation for each enabled local
 ::: warning
 Please note that the **following attribute codes cannot be used** in Akeneo PIM:    
 `id`, `associationTypes`, `category`, `categories`, `categoryId`, `completeness`, `enabled`, `family`, `Family`, `groups`, `associations`, `products`, `scope`, `treeId`, `values`, `label`, `parent`.    
-We strongly recommend you to do not use any of these codes even if the casse is different, for instance `Id`, `Groups`.
+We strongly recommend you to do not use any of these codes even if the letter case is different, for instance `Id`, `Groups`.
 :::
 
 ::: warning


### PR DESCRIPTION
added `Family` in the list of codes that cannot be used.
And the sentence: "We strongly recommend you to do not use any of these codes even if the casse is different, for instance `Id`, `Groups`."