### PR TITLE
v2- Change Algolia's solution tag for the pim v2.x

### DIFF
--- a/src/partials/layout.handlebars
+++ b/src/partials/layout.handlebars
@@ -5,7 +5,7 @@
     <title>{{title}}</title>
     <meta name="description" content="Help center">
     <meta name="viewport" content="width=device-width, user-scalable=no, initial-scale=1.0, maximum-scale=1.0, minimum-scale=1.0">
-    <meta name="docsearch:solution" content="pim">
+    <meta name="docsearch:solution" content="pimv2">
     <script src="/pim/{{majorVersion}}/js/jquery.min.js"></script>
     <script src='/pim/{{majorVersion}}/js/bootstrap.min.js'></script>
     <script src='/pim/{{majorVersion}}/js/docsearch.min.js'></script>
@@ -42,7 +42,7 @@
           inputSelector: '#docSearch-input',
           debug: false, // Set debug to true if you want to inspect the dropdown
           algoliaOptions: {
-            'facetFilters': ["solution:pim"]
+            'facetFilters': ["solution:pimv2"]
           }
       });
     }


### PR DESCRIPTION
With the new PIM v3, we need to differenciate the results from Algolia for PIM v2 vs PIM v3.
We added a separate tag: 'pimv2' instead of 'pim'