### PR TITLE
1.7 is also desprecated

### DIFF
--- a/src/indexes/index-older.handlebars
+++ b/src/indexes/index-older.handlebars
@@ -25,7 +25,8 @@
         <div class="row">
             <div class="col-xs-12">
                 <img class="img-responsive center-block" src="./img/illus-using.svg"/>
-                <h1 class="text-center emphasis">The complete guides to master previous PIM versions</h1>
+                <h1 class="text-center emphasis">The complete guides to master our previous PIM versions</h1>
+                <h3 class="text-center text-akeneo"><em>The versions below are not supported by our team anymore.</em></h3>
             </div>
         </div>
     </div>
@@ -52,14 +53,8 @@
                 </div>
             </div>
         </div>
-    </div>
-</div>
-<div class="jumbotron jumbotron-deprecated-user-guides">
-    <div class="container">
         <div class="row">
             <div class="col-xs-12">
-                <h3 class="text-akeneo"><em>The versions below are not supported by our team anymore.</em></h3>
-                <p> It's not that we don't like them, it's just that they have run their course and now, they need to rest a little. 😊</p>
                 <h1>v1.6</h1>
                 <div class="row">
                     <div class="col-md-4 text-center">
@@ -78,6 +73,10 @@
                         <a href="./pdf-user-guides/EN-Administrator-guide-PIM-CE-EE-1.6.pdf" download="Administrator user guide 1.6.pdf" class="btn btn-info" onclick="ga('send', 'event', 'download guides', 'Administrator', '1.6');">Download the pdf</a>
                     </div>
                 </div>
+            </div>
+        </div>
+        <div class="row">
+            <div class="col-xs-12">
                 <h1>v1.5</h1>
                 <div class="row">
                     <div class="col-md-4 text-center">
@@ -98,9 +97,6 @@
                 </div>
             </div>
         </div>
-    </div>
-    <hr>
-    <div class="container">
         <div class="row">
             <div class="col-xs-12">
                 <h1>v1.4</h1>
@@ -123,9 +119,6 @@
                 </div>
             </div>
         </div>
-    </div>
-    <hr>
-    <div class="container">
         <div class="row">
             <div class="col-xs-12">
                 <h1>v1.3</h1>


### PR DESCRIPTION
Layout change to mark all versions before the 2.x as deprecated.

Now the "older versions" page will look like this.
![Screenshot 2019-06-24 at 13 11 15](https://user-images.githubusercontent.com/25225430/60014731-f82a9a80-9681-11e9-9625-323fd7891c1e.png)
