### PR TITLE
Fix dead links

### DIFF
--- a/content/md/first-steps/manage-your-account.md
+++ b/content/md/first-steps/manage-your-account.md
@@ -3,7 +3,7 @@ id: manage-your-account
 themes: first-steps
 title: Manage your **account**
 popular: false
-related: manage-your-users, what-is-a-user-role, what-is-a-user-group, build-your-user-roles, build-your-user-groups, workflow
+related: manage-your-users, what-is-a-role, what-is-a-user-group, build-your-user-roles, build-your-user-groups, workflow
 ---
 
 # Access your account information
@@ -53,7 +53,7 @@ If no default filters are defined, the system attributes (family, groups, status
 
 ## Your groups and roles
 
-To edit your [user groups](what-is-a-user-group.html) and [roles](what-is-a-user-roles.html):
+To edit your [user groups](what-is-a-user-group.html) and [roles](what-is-a-role.html):
 1. Click on the `Groups and Roles` tab
 1. On the top of the page, you will see the user group(s) you belong to, and then your user role(s). Check/uncheck to change your groups/roles.
 2. Click on `Save` to save your changes

--- a/content/md/imports-exports/imports.md
+++ b/content/md/imports-exports/imports.md
@@ -115,7 +115,7 @@ In the case of *product imports*, the PIM takes into account your permissions ba
 - you **only have an edit rights** on the products that are in the `Audio video` category, if you try to import product information for these products, the import will automatically create draft for you as you cannot direclty update these products
 - you **only have a view right** on the products that are in the `Goodies` category, if you try to import product information for these products, the import won't work for these products and you will receive errors saying that you cannot modify these products
 
-If you want to know more about how the rights on product data works in the PIM, take a look to the [Access rights in products](access-rights-on-rpoducts) article.
+If you want to know more about how the rights on product data works in the PIM, take a look to the [Access rights on products](access-rights-on-products.html) article.
 
 ### Rights on import execution
 The permission to execute imports can be customized for each import profile. So if you cannot launch an import, be sure that you have the right to run it in the `Permissions` tab of your import profile in edition mode. See the [Access rights on imports/exports](access-rights-on-imports-exports.html) article for more details.


### PR DESCRIPTION
2 dead links detected :
In "imports" a link to the "access right on products" article
In "Manage your account" a link to the "What is a user role" article