### PR TITLE
Proposal for related article links

### DIFF
--- a/content/md/what-is/what-is-a-locale_fr.md
+++ b/content/md/what-is/what-is-a-locale_fr.md
@@ -2,6 +2,9 @@
 id: what-is-a-locale
 themes: first-steps, akeneo-concepts
 title: Qu'est-ce qu'une **locale**?
+popular: false
+ee-only: false
+related: manage-your-locales, what-is-an-attribute, access-rights-on-products
 ---
 
 # Définition d'une locale


### PR DESCRIPTION
The goal of this modification is to manage the translated related articles :
Before this modification, many similar related articles may appear in the "Related articles" part of an article.
Exemple :
If you look at the "manage your rules" article, you will see 2 links one in English and 1 in French (even if you choose FR or EN as language for the helpcenter)
After the modification, you will only have once : if translated in the selected language, we will get it, if not, we will show the English translation.

The 2nd part of this modification is to prevent any dead link, using the article linked page to be sure to have to good link.

The third part is just a fix on missing related articles for FR translation of an article