### PR TITLE
Add a breadcrumb

### DIFF
--- a/src/article.handlebars
+++ b/src/article.handlebars
@@ -4,6 +4,7 @@
     <div class="container">
         <div class="row">
             <div class="col-xs-12">
+                <p class="breadcrumb text-muted"><a href="/">Home</a> / <a href="/pim/serenity">PIM help center</a> / {{{titleWithBold}}}</p>
                 <h1 class="article-title docSearch-mainTitle">{{{titleWithBold}}}</h1>
                 {{#if eeOnly}}<p class="small"><em>Only available in our <a href="https://www.akeneo.com/enterprise-edition/?source=akeneo-help">Entreprise Edition</a></em></p>{{/if}}
             </div>

--- a/styles/typography.less
+++ b/styles/typography.less
@@ -6,6 +6,7 @@ h1{
         font-weight: 300;
         color: @brand-akeneo;
         font-style: italic;
+        margin-top: @spacing-base / 1.5;
     }
 }
 
@@ -49,6 +50,13 @@ ol{
             border-radius: @border-radius-base;
         }
     }
+}
+
+.breadcrumb {
+    margin-top: @spacing-base / 2;
+    background: none;
+    margin-bottom: inherit;
+    padding: 0;
 }
 
 .text-akeneo{


### PR DESCRIPTION
You were all waiting for it!
THE BREADCRUMB that will allow you to easily go back to the PIM help center main page.
![Screenshot 2020-02-03 at 17 15 00](https://user-images.githubusercontent.com/25225430/73670130-fa89b400-46a8-11ea-9716-f2b0403505e1.png)

Note: It's more difficult to go back to the Themes pages because we can't know where the article is (in Julia or Peter or both sections). This PR only allows going back to the root page of the PIM help center.