### PR TITLE
Fix assets transformation broken link

### DIFF
--- a/content/md/assets/assets-transformation.md
+++ b/content/md/assets/assets-transformation.md
@@ -30,7 +30,7 @@ For each transformation, we define:
 You can have up to **10** different transformations for one given asset family and each transformation can perform several operations.
 :::
 
-You can define the asset transformations via the [API](#https://api.akeneo.com/documentation/asset-manager.html#introduction) or directly in the PIM user interface, by editing a JSON field.
+You can define the asset transformations via the [API](https://api.akeneo.com/documentation/asset-manager.html#introduction) or directly in the PIM user interface, by editing a JSON field.
 
 ![Assets Transformations Format](../img/Assets_TransformationsFormat.png)
 


### PR DESCRIPTION
Here https://help.akeneo.com/pim/v4/articles/assets-transformation.html

This API link was redirecting to `https://help.akeneo.com/pim/v4/articles/assets-transformation.html#https://api.akeneo.com/documentation/asset-manager.html#introduction`

