### PR TITLE
Fix the search by version

### DIFF
--- a/src/partials/layout.handlebars
+++ b/src/partials/layout.handlebars
@@ -43,7 +43,7 @@
           inputSelector: '#docSearch-input',
           debug: false, // Set debug to true if you want to inspect the dropdown
           algoliaOptions: {
-            'facetFilters': ["solution:pimv3"]
+            'facetFilters': ["solution:pimSerenity"]
           }
       });
     }

--- a/src/partials/layout.handlebars
+++ b/src/partials/layout.handlebars
@@ -5,7 +5,7 @@
     <title>{{title}}</title>
     <meta name="description" content="Help center">
     <meta name="viewport" content="width=device-width, user-scalable=no, initial-scale=1.0, maximum-scale=1.0, minimum-scale=1.0">
-    <meta name="docsearch:solution" content="pimv3">
+    <meta name="docsearch:solution" content="pimSerenity">
     <script src="/pim/{{majorVersion}}/js/jquery.min.js"></script>
     <script src='/pim/{{majorVersion}}/js/bootstrap.min.js'></script>
     <script src='/pim/{{majorVersion}}/js/docsearch.min.js'></script>


### PR DESCRIPTION
There is a bug when you search over the Serenity version of the doc. It shows also the v3 version of the doc in Serenity.

That should fix it. What do you think @bgouraud?