### PR TITLE
Fix navigation for xs screens

### DIFF
--- a/src/index.handlebars
+++ b/src/index.handlebars
@@ -4,11 +4,20 @@
 <nav class="navbar navbar-default navbar-fixed-top">
     <div class="container-fluid">
         <div class="navbar-header">
+            <button type="button" class="navbar-toggle collapsed" data-toggle="collapse" data-target="#navbar-collapse" aria-expanded="false">
+                <span class="sr-only">Toggle navigation</span>
+                <span class="icon-bar"></span>
+                <span class="icon-bar"></span>
+                <span class="icon-bar"></span>
+              </button>
             <a class="navbar-brand" href="/">
                 <img height="20" src="./img/akeneo.svg"></img>
             </a>
         </div>
-        {{> version-navigation}}
+
+        <div class="collapse navbar-collapse" id="navbar-collapse">
+            {{> version-navigation}}
+        </div>
     </div>
 </nav>
 <div class="jumbotron jumbotron-search">

--- a/src/partials/navbar-with-search.handlebars
+++ b/src/partials/navbar-with-search.handlebars
@@ -1,15 +1,24 @@
 <nav class="navbar navbar-default navbar-fixed-top">
     <div class="container-fluid">
         <div class="navbar-header">
+            <button type="button" class="navbar-toggle collapsed" data-toggle="collapse" data-target="#navbar-collapse" aria-expanded="false">
+                <span class="sr-only">Toggle navigation</span>
+                <span class="icon-bar"></span>
+                <span class="icon-bar"></span>
+                <span class="icon-bar"></span>
+            </button>
             <a class="navbar-brand" href="/">
                 <img height="20" src="/pim/{{majorVersion}}/img/akeneo.svg"></img>
             </a>
         </div>
-        <form class="navbar-form navbar-left">
-            <div class="form-group form-search">
-                <input id="docSearch-input" type="text" class="form-control" placeholder="Search for PIM help...">
-            </div>
-        </form>
-        {{> version-navigation}}
+
+        <div class="collapse navbar-collapse" id="navbar-collapse">
+            <form class="navbar-form navbar-left">
+                <div class="form-group form-search">
+                    <input id="docSearch-input" type="text" class="form-control" placeholder="Search for PIM help...">
+                </div>
+            </form>
+            {{> version-navigation}}
+        </div>
     </div>
 </nav>

--- a/styles/nav.less
+++ b/styles/nav.less
@@ -3,22 +3,44 @@ nav{
     &.scroll{
         .box-shadow(0 5px 25px 0 @gray-light);
     }
+
     &.navbar-white{
         background-color: white;
         border-color: white;
     }
     &.navbar-default{
-        .navbar-header{
-            float: left;
+        .navbar-toggle{
+            border-color: @navbar-default-color;
+            &:hover, &:focus {
+                background-color: darken(@navbar-default-bg,5%);
+            }
+            .icon-bar{
+                background-color: @navbar-default-color;
+            }
         }
         .navbar-brand{
             padding: 21px 30px;
+        }
+        .collapse.in, .collapsing {
+            .navbar-right{
+                float: initial;
+            }
+            li.active>a,
+            li.active>a:hover{
+                &:after{
+                    right: unset;
+                    left: 15px;
+                }
+            }
+            a:hover:after {
+                right: unset;
+                left: 15px;
+            }
         }
         .navbar-nav {
             margin-top: 0;
             margin-bottom: 0;
             &.navbar-right{
-                float: right;
                 &:last-child {
                     margin-right: -15px;
                 }


### PR DESCRIPTION
The navigation was a bit broken for xs screens since its last rework. This should fix it.

It adds a button on which you can click to display the nav. Here is an example.
![Screenshot 2020-05-26 at 18 22 03](https://user-images.githubusercontent.com/25225430/82925362-e6323580-9f7d-11ea-885d-0c06fa71c032.png)
