### PR TITLE
Fix the scan by Algolia

### DIFF
--- a/src/index.handlebars
+++ b/src/index.handlebars
@@ -1,11 +1,17 @@
 {{!-- Homepage --}}
 {{#> layout  title="Akeneo Help center"}}
 {{> serenity-updates-button}}
+
+{{!--
+    Generate statically hidden links for algolia indexation, as the dropdown is loaded in JS,
+    which prevents to correctly scan the website by Algolia
+ --}}
 <div class="hidden">
-    <a href="/pim/v4/">v4 EE/CE</a>
-    <a href="/pim/v3/">v3 EE/CE</a>
-    <a href="/pim/v2/">v2 EE/CE</a>
+{{#each versions}}
+    <a href="{{url}}">{{label}}</a>
+{{/each}}
 </div>
+
 <nav class="navbar navbar-default navbar-fixed-top">
     <div class="container-fluid">
         <div class="navbar-header">

--- a/tasks/landings.js
+++ b/tasks/landings.js
@@ -1,6 +1,7 @@
 /**
  * Compile the homepage with Handlebars
  */
+var fs = require('fs');
 var gulp = require('gulp');
 var hbs = require('handlebars');
 var gulpHandlebars = require('gulp-handlebars-html')(hbs);
@@ -33,6 +34,9 @@ gulp.task('grab-related-articles', function(){
 
 // This task builds the homepage
 gulp.task('landings', ['clean-dist','less', 'grab-related-articles'], function() {
+    const rawVersions = fs.readFileSync('src/versions.json');
+    const versions = JSON.parse(rawVersions);
+
     // When all information about the popular articles are gathered,
     // we inject this data into the Handlebars template of the homepage.
     // Finally, the resulting HTML is saved into "dist".
@@ -41,7 +45,8 @@ gulp.task('landings', ['clean-dist','less', 'grab-related-articles'], function()
                 return gulp.src(file.path)
                         .pipe(gulpHandlebars({
                             popularArticles: popularArticles,
-                            majorVersion: majorVersion
+                            majorVersion: majorVersion,
+                            versions: versions
                         }, {
                             partialsDirectory: ['./src/partials']
                         }))


### PR DESCRIPTION
As the dropdown is in JS, Algolia cannot scan the links to follow. 
The consequence is that the v4 was not analyzed at all by Algolia.

The fix is just to generate it from the versions.json. As it follows the links from the serenity version at first, the links will always be up to date. Indeed, only the versions.json from master is the source of truth about the dropdown.