### PR TITLE
Get the previous month correctly when we are the 31th to filter updates to be published

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -21,7 +21,7 @@ jobs:
                   command: HOSTNAME=$STAGING_HOSTNAME PORT=$STAGING_PORT HELP_CENTER_URL="https://${STAGING_HOSTNAME}/" make deploy
             - run:
                   name: Push announcements of communication panel of the PIM into firestore
-                  command: FIREBASE_PROJECT=$STAGING_FIREBASE_PROJECT GOOGLE_APPLICATION_CREDENTIALS="$STAGING_GOOGLE_APPLICATION_CREDENTIALS" ONLY_PREVIOUS_MONTH_UPDATES=true make push-announcements
+                  command: FIREBASE_PROJECT=$STAGING_FIREBASE_PROJECT GOOGLE_APPLICATION_CREDENTIALS="$STAGING_GOOGLE_APPLICATION_CREDENTIALS" make push-announcements
             - run:
                   name: Push serverless functions into firebase to expose communication panel API
                   command: FIREBASE_PROJECT=$STAGING_FIREBASE_PROJECT FIREBASE_TOKEN=$FIREBASE_TOKEN make deploy-firebase-functions
@@ -34,7 +34,7 @@ jobs:
             - add_ssh_keys
             - run:
                   name: Deploy on production server
-                  command: ONLY_PREVIOUS_MONTH_UPDATES=true HOSTNAME=$PROD_HOSTNAME PORT=$PROD_PORT ONLY_PREVIOUS_MONTH_UPDATES=true make deploy
+                  command: HOSTNAME=$PROD_HOSTNAME PORT=$PROD_PORT ONLY_PREVIOUS_MONTH_UPDATES=true make deploy
             - run:
                   name: Push announcements of communication panel of the PIM into firestore
                   command: FIREBASE_PROJECT=$PROD_FIREBASE_PROJECT GOOGLE_APPLICATION_CREDENTIALS="$PROD_GOOGLE_APPLICATION_CREDENTIALS" make push-announcements

--- a/tasks/build-monthly-updates-as-html.js
+++ b/tasks/build-monthly-updates-as-html.js
@@ -149,7 +149,7 @@ function getTocMarkdown() {
 function keepUpdatesFromPreviousMonths(folderName, generateAllUpdates) {
     const currentDate = new Date(Date.now());
     const dayOfMonth = currentDate.getDate();
-    const previousMonthDate = dayOfMonth < 5 ? new Date(currentDate.setMonth(currentDate.getMonth() - 2)) : new Date(currentDate.setMonth(currentDate.getMonth() - 1));
+    const previousMonthDate = dayOfMonth < 5 ? new Date(currentDate.setMonth(currentDate.getMonth() - 2)) : new Date(currentDate.setDate(0));
 
     const year = new Intl.DateTimeFormat('en', { year: 'numeric' }).format(previousMonthDate);
     const month = new Intl.DateTimeFormat('en', { month: '2-digit' }).format(previousMonthDate);

--- a/tasks/build-monthly-updates-as-json.js
+++ b/tasks/build-monthly-updates-as-json.js
@@ -204,7 +204,8 @@ function keepUpdatesFromPreviousMonths(generateAllUpdates) {
 
         const currentDate = new Date(Date.now());
         const dayOfMonth = currentDate.getDate();
-        const previousMonthDate = dayOfMonth < 5 ? new Date(currentDate.setMonth(currentDate.getMonth() - 2)) : new Date(currentDate.setMonth(currentDate.getMonth() - 1));
+
+        const previousMonthDate = dayOfMonth < 5 ? new Date(currentDate.setMonth(currentDate.getMonth() - 2)) : new Date(currentDate.setDate(0));
 
         const year = new Intl.DateTimeFormat('en', { year: 'numeric' }).format(previousMonthDate);
         const month = new Intl.DateTimeFormat('en', { month: '2-digit' }).format(previousMonthDate);

--- a/tests/updates/build-monthly-updates-as-html.test.js
+++ b/tests/updates/build-monthly-updates-as-html.test.js
@@ -24,12 +24,39 @@ test('Generate the static html about the updates of the PIM', done => {
  * The March month is not finished, so the updates are still written by the PM and not ready to be published *in production*.
  * Before the 05, it does not generate the update for february, as it's waiting for validation.
  */
-test('When we are from 05 to 30 March 2020, generate the updates until February 2020', done => {
+test('When we are from 05 to 31 March 2020, generate the updates until February 2020', done => {
     del(['tmp/*']);
     jest
         .spyOn(global.Date, 'now')
         .mockImplementation(() =>
             new Date('2020-03-05T00:00:00.000Z').valueOf()
+        );
+
+    const stream = generateUpdates('./tests/updates/nominal_case/', './tmp', false);
+
+    stream.on('finish', () => {
+        try {
+            expect(fs.existsSync('./tmp/2020-02.html')).toBeTruthy();
+            expect(fs.existsSync('./tmp/2020-03.html')).toBeFalsy();
+            done();
+        } catch (error) {
+            done(error);
+        }
+    });
+});
+
+/**
+ * If you just substract a month in JS, it transform 03/31 in 02/31 which does exist. Therefore, JS transforms it as
+ * 03/03... which creates a bug in the filtering.
+ *
+ * This test guarantees that this behavior does not occur and that it correctly handles this case.
+ */
+test('When we are in March 31th 2020, generate the updates until February 2020', done => {
+    del(['tmp/*']);
+    jest
+        .spyOn(global.Date, 'now')
+        .mockImplementation(() =>
+            new Date('2020-03-31T00:00:00.000Z').valueOf()
         );
 
     const stream = generateUpdates('./tests/updates/nominal_case/', './tmp', false);

--- a/tests/updates/build-monthly-updates-as-json.test.js
+++ b/tests/updates/build-monthly-updates-as-json.test.js
@@ -33,12 +33,44 @@ test('It generates all updates in the json file by default to deploy everything 
  * The March month is not finished, so the updates are still written by the PM and not ready to be published *in production*.
  * Before the 05, it does not generate the update for february, as it's waiting for validation.
  */
-test('When we are from 05 to 30 March 2020, generate the updates until February 2020', done => {
+test('When we are from 05 to 31 March 2020, generate the updates until February 2020', done => {
     del(['tmp/*']);
     jest
         .spyOn(global.Date, 'now')
         .mockImplementation(() =>
             new Date('2020-03-05T00:00:00.000Z').valueOf()
+        );
+
+    const stream = updatesAsJson('./tests/updates/nominal_case/**/*.md', './tmp/', 'test.json', false);
+
+    stream.on('end', () => {
+        const rawData = fs.readFileSync('./tmp/test.json');
+        const data = JSON.parse(rawData);
+
+        const expectedRawData = fs.readFileSync('./tests/updates/nominal_case/expected_updates_only_february.json');
+        const expectedData = JSON.parse(expectedRawData);
+
+        try {
+            expect(data.sort(sortJson)).toStrictEqual(expectedData.sort(sortJson));
+            done();
+        } catch (error) {
+            done(error);
+        }
+    });
+});
+
+/**
+ * If you just substract a month in JS, it transform 03/31 in 02/31 which does exist. Therefore, JS transforms it as
+ * 03/03... which creates a bug in the filtering.
+ *
+ * This test guarantees that this behavior does not occur and that it correctly handles this case.
+ */
+test('When we are in March 31th 2020, generate the updates until February 2020', done => {
+    del(['tmp/*']);
+    jest
+        .spyOn(global.Date, 'now')
+        .mockImplementation(() =>
+            new Date('2020-03-31T00:00:00.000Z').valueOf()
         );
 
     const stream = updatesAsJson('./tests/updates/nominal_case/**/*.md', './tmp/', 'test.json', false);


### PR DESCRIPTION
Fix bug occurring only the 31th of the month.