### PR TITLE
Remove 3.0 as being still supported

### DIFF
--- a/tasks/build-whats-new-page.js
+++ b/tasks/build-whats-new-page.js
@@ -26,7 +26,7 @@ const orderedVersions = {
     '21': { 'name': '2.1', 'isSupported': false },
     '22': { 'name': '2.2', 'isSupported': false },
     '23': { 'name': '2.3', 'isSupported': false },
-    '30': { 'name': '3.0', 'isSupported': true },
+    '30': { 'name': '3.0', 'isSupported': false },
     '31': { 'name': '3.1', 'isSupported': false },
     '32': { 'name': '3.2', 'isSupported': true },
     '40': { 'name': '4.0', 'isSupported': true },


### PR DESCRIPTION
3.0 is not supported since today.