### PR TITLE
Better description for one October news

### DIFF
--- a/content/updates/2020-10/5-New-filters-for-rules-conditions.md
+++ b/content/updates/2020-10/5-New-filters-for-rules-conditions.md
@@ -9,7 +9,7 @@ pim_announcement_audience:
 ::: meta-data type="New" features="Automation, Productivity" available="early October" link-to-doc="../articles/manage-your-rules.html#available-conditions"
 :::
 
-New condition filters are available in the rules engine in the rules engine to help you better narrow down your product selection for a rule. For instance, you can now target specific product models or variants, or a list of product identifiers.
+New condition filters are available in the rules engine to help you better narrow down your product selection for a rule. For instance, you can now target specific product models or variants, or a list of product identifiers.
 
 You can now filter on:
 - the entity type: to target product models or products and variant products,

--- a/content/updates/2020-10/5-New-filters-for-rules-conditions.md
+++ b/content/updates/2020-10/5-New-filters-for-rules-conditions.md
@@ -9,7 +9,9 @@ pim_announcement_audience:
 ::: meta-data type="New" features="Automation, Productivity" available="early October" link-to-doc="../articles/manage-your-rules.html#available-conditions"
 :::
 
-New filters are available in the rules engine to help you better define your conditions. You can now filter on:
+New condition filters are available in the rules engine in the rules engine to help you better narrow down your product selection for a rule. For instance, you can now target specific product models or variants, or a list of product identifiers.
+
+You can now filter on:
 - the entity type: to target product models or products and variant products,
 - family variants: to target products belonging to one or several family variants, or products with one or no family variant,
 - parents: to target specific product parents or products without parents
@@ -17,7 +19,7 @@ New filters are available in the rules engine to help you better define your con
 
 ![The new filters in action](../img/new-filters-for-rules-conditions.png)
 
-Condition filters enable you to narrow down the targeted products for a rule. The more precise your rule conditions, the faster it will be run. So don't hesitate to use those new filters.
+Don't hesitate to use those new filters. The more precise your rule conditions, the faster it will be run.
 
 ::: more
 [How to manage your rules?](../articles/manage-your-rules.html)


### PR DESCRIPTION
Because it is not correctly rendered inside the communication panel.
Indeed, we should avoid lists in the first paragraph of the news.