### PR TITLE
Wrong URLs in Serenity banner

### DIFF
--- a/src/partials/serenity-banner.handlebars
+++ b/src/partials/serenity-banner.handlebars
@@ -2,7 +2,7 @@
     <div class="container">
         <div class="row">
             <div class="col-xs-12">
-                <p><img width="25" src="/pim/serenity/img/hello.svg"></img> <b> Heads up!</b> This is the documentation for our <a href="versions-in-detail.html#serenity">Akeneo Serenity</a> version. Serenity clients benefit from exclusive access to the latest Akeneo PIM features.<br>If you're interested in other PIM versions, click on the drop down menu on the top right corner or check out <a href="versions-in-detail.html">everything you need to know about your version</a>.</p>
+                <p><img width="25" src="/pim/serenity/img/hello.svg"></img> <b> Heads up!</b> This is the documentation for our <a href="https://help.akeneo.com/pim/serenity/versions-in-detail.html#serenity">Akeneo Serenity</a> version. Serenity clients benefit from exclusive access to the latest Akeneo PIM features.<br>If you're interested in other PIM versions, click on the drop down menu on the top right corner or check out <a href="https://help.akeneo.com/pim/serenity/versions-in-detail.html">everything you need to know about your version</a>.</p>
             </div>
         </div>
     </div>

--- a/src/partials/serenity-banner.handlebars
+++ b/src/partials/serenity-banner.handlebars
@@ -2,7 +2,7 @@
     <div class="container">
         <div class="row">
             <div class="col-xs-12">
-                <p><img width="25" src="/pim/serenity/img/hello.svg"></img> <b> Heads up!</b> This is the documentation for our <a href="https://help.akeneo.com/pim/serenity/versions-in-detail.html#serenity">Akeneo Serenity</a> version. Serenity clients benefit from exclusive access to the latest Akeneo PIM features.<br>If you're interested in other PIM versions, click on the drop down menu on the top right corner or check out <a href="https://help.akeneo.com/pim/serenity/versions-in-detail.html">everything you need to know about your version</a>.</p>
+                <p><img width="25" src="/pim/serenity/img/hello.svg"></img> <b> Heads up!</b> This is the documentation for our <a href="/pim/serenity/versions-in-detail.html#serenity">Akeneo Serenity</a> version. Serenity clients benefit from exclusive access to the latest Akeneo PIM features.<br>If you're interested in other PIM versions, click on the drop down menu on the top right corner or check out <a href="/pim/serenity/versions-in-detail.html">everything you need to know about your version</a>.</p>
             </div>
         </div>
     </div>


### PR DESCRIPTION
It looks like it adds /articles/ in the URL when it's shortened and then we land on a 404.