### PR TITLE
Add year in Serenity updates

### DIFF
--- a/content/updates/index.json
+++ b/content/updates/index.json
@@ -1,51 +1,56 @@
 {
+  "2021-01": {
+    "title": "🍁 January 2021 Serenity updates",
+    "description": "New Serenity updates of January",
+    "img": "illus-november-20.svg"
+  },
   "2020-11": {
-    "title": "🍁 November Serenity updates",
+    "title": "🍁 November 2020 Serenity updates",
     "description": "New Serenity updates of November",
     "img": "illus-november-20.svg"
   },
   "2020-10": {
-    "title": "🎃 October Serenity updates",
+    "title": "🎃 October 2020 Serenity updates",
     "description": "October rhymes with better productivity, quickly automate your content creation with the rules engine, easily work with product variants and models thanks to our product grid enhancements, better prioritize your data quality focus areas and benefit from other improvements.",
     "img": "illus-october-20.svg"
   },
   "2020-09": {
-    "title": "🐿️ September Serenity updates",
+    "title": "🐿️ September 2020 Serenity updates",
     "description": "This month, we completed the Rules Builder, our new rules engine user interface, and enriched it with additional rules features. We extended the capabilities of product exports to offer you more flexibility and we added new API filters to ease data synchronization.",
     "img": "illus-september-20.svg"
   },
   "2020-08": {
-    "title": "⛺ August Serenity updates",
+    "title": "⛺ August 2020 Serenity updates",
     "description": "No vacation for new features! This summer, our teams continued to work on the rules engine user interface: it's boosted with new actions and conditions. We also improved our API usability by adding search filters when retrieving attributes and families.",
     "img": "illus-august-20.svg"
   },
   "2020-07": {
-    "title": "🍦 July Serenity updates",
+    "title": "🍦 July 2020 Serenity updates",
     "description": "In July, the rules engine started a makeover to offer you a new screen to more easily create or update rules; but also check out our new association type, as well as other improvements on the Connection messages, the spell-check feature and date rules condition!",
     "img": "illus-july-20.svg"
   },
   "2020-06": {
-    "title": "☀️ June Serenity updates",
+    "title": "☀️ June 2020 Serenity updates",
     "description": "In June, teams will be more empowered than ever! Check out our new product duplication feature, get a better user experience with our new attribute options screen and our rules engine updates, and execute asset naming conventions with more flexibility.",
     "img": "illus-june-20.svg"
   },
   "2020-05": {
-    "title": "🌺 May Serenity updates",
+    "title": "🌺 May 2020 Serenity updates",
     "description": "The month of May brings improvements for error management on Connections, more flexibility for your data modeling thanks to a brand new association type, more control and visibility on the ongoing PIM jobs and additional features for the rules engine!",
     "img": "illus-may-20.svg"
   },
   "2020-04": {
-    "title": "🦋 April Serenity updates",
+    "title": "🦋 April 2020 Serenity updates",
     "description": "This month is full of new features and updates! Discover our new measurement families, improvements on product associations and on the Connection dashboard. But that's not it! Find out new rules actions and our latest data quality improvements.",
     "img": "illus-april-20.svg"
   },
   "2020-03": {
-    "title": "🌱 March Serenity updates",
+    "title": "🌱 March 2020 Serenity updates",
     "description": "This month, enhance your productivity thanks to new rules engine capabilities, better model your catalog with new measurement units and families, and finally keep on improving your product information with data quality extended features.",
     "img": "illus-march-20.svg"
   },
   "2020-02": {
-    "title": "❄️ February Serenity updates",
+    "title": "❄️ February 2020 Serenity updates",
     "description": "This month Serenity updates include two new improvements: a new asset management operation to optimize the weight of your transformed files and new warning messages on usernames for the Connections.",
     "img": "illus-february-20.svg"
   }

--- a/content/updates/index.json
+++ b/content/updates/index.json
@@ -1,56 +1,56 @@
 {
   "2021-01": {
-    "title": "🍁 January 2021 Serenity updates",
+    "title": "January 2021 Serenity updates",
     "description": "New Serenity updates of January",
     "img": "illus-november-20.svg"
   },
   "2020-11": {
-    "title": "🍁 November 2020 Serenity updates",
+    "title": "November 2020 Serenity updates",
     "description": "New Serenity updates of November",
     "img": "illus-november-20.svg"
   },
   "2020-10": {
-    "title": "🎃 October 2020 Serenity updates",
+    "title": "October 2020 Serenity updates",
     "description": "October rhymes with better productivity, quickly automate your content creation with the rules engine, easily work with product variants and models thanks to our product grid enhancements, better prioritize your data quality focus areas and benefit from other improvements.",
     "img": "illus-october-20.svg"
   },
   "2020-09": {
-    "title": "🐿️ September 2020 Serenity updates",
+    "title": "September 2020 Serenity updates",
     "description": "This month, we completed the Rules Builder, our new rules engine user interface, and enriched it with additional rules features. We extended the capabilities of product exports to offer you more flexibility and we added new API filters to ease data synchronization.",
     "img": "illus-september-20.svg"
   },
   "2020-08": {
-    "title": "⛺ August 2020 Serenity updates",
+    "title": "August 2020 Serenity updates",
     "description": "No vacation for new features! This summer, our teams continued to work on the rules engine user interface: it's boosted with new actions and conditions. We also improved our API usability by adding search filters when retrieving attributes and families.",
     "img": "illus-august-20.svg"
   },
   "2020-07": {
-    "title": "🍦 July 2020 Serenity updates",
+    "title": "July 2020 Serenity updates",
     "description": "In July, the rules engine started a makeover to offer you a new screen to more easily create or update rules; but also check out our new association type, as well as other improvements on the Connection messages, the spell-check feature and date rules condition!",
     "img": "illus-july-20.svg"
   },
   "2020-06": {
-    "title": "☀️ June 2020 Serenity updates",
+    "title": "June 2020 Serenity updates",
     "description": "In June, teams will be more empowered than ever! Check out our new product duplication feature, get a better user experience with our new attribute options screen and our rules engine updates, and execute asset naming conventions with more flexibility.",
     "img": "illus-june-20.svg"
   },
   "2020-05": {
-    "title": "🌺 May 2020 Serenity updates",
+    "title": "May 2020 Serenity updates",
     "description": "The month of May brings improvements for error management on Connections, more flexibility for your data modeling thanks to a brand new association type, more control and visibility on the ongoing PIM jobs and additional features for the rules engine!",
     "img": "illus-may-20.svg"
   },
   "2020-04": {
-    "title": "🦋 April 2020 Serenity updates",
+    "title": "April 2020 Serenity updates",
     "description": "This month is full of new features and updates! Discover our new measurement families, improvements on product associations and on the Connection dashboard. But that's not it! Find out new rules actions and our latest data quality improvements.",
     "img": "illus-april-20.svg"
   },
   "2020-03": {
-    "title": "🌱 March 2020 Serenity updates",
+    "title": "March 2020 Serenity updates",
     "description": "This month, enhance your productivity thanks to new rules engine capabilities, better model your catalog with new measurement units and families, and finally keep on improving your product information with data quality extended features.",
     "img": "illus-march-20.svg"
   },
   "2020-02": {
-    "title": "❄️ February 2020 Serenity updates",
+    "title": "February 2020 Serenity updates",
     "description": "This month Serenity updates include two new improvements: a new asset management operation to optimize the weight of your transformed files and new warning messages on usernames for the Connections.",
     "img": "illus-february-20.svg"
   }

--- a/content/updates/index.json
+++ b/content/updates/index.json
@@ -1,9 +1,4 @@
 {
-  "2021-01": {
-    "title": "January 2021 Serenity updates",
-    "description": "New Serenity updates of January",
-    "img": "illus-november-20.svg"
-  },
   "2020-11": {
     "title": "November 2020 Serenity updates",
     "description": "New Serenity updates of November",

--- a/src/monthly-updates-index.handlebars
+++ b/src/monthly-updates-index.handlebars
@@ -23,6 +23,9 @@
             </div>
         </div>
         <div class="row">
+            <div class="col-xs-12">
+                <h2>Year 2020</h1>
+            </div>
             {{#each monthlyUpdates as |monthlyUpdate id|}}
                 <div class="col-xs-12 col-sm-6 col-md-4">
                     <div class="persona">

--- a/src/monthly-updates-index.handlebars
+++ b/src/monthly-updates-index.handlebars
@@ -23,24 +23,26 @@
             </div>
         </div>
         <div class="row">
-            <div class="col-xs-12">
-                <h2>Year 2020</h1>
-            </div>
-            {{#each monthlyUpdates as |monthlyUpdate id|}}
-                <div class="col-xs-12 col-sm-6 col-md-4">
-                    <div class="persona">
-                        <a href="{{id}}.html">
-                            <img class="img-responsive center-block" src="../img/{{img}}"/>
-                            <h3 class="text-center">{{title}}</h3>
-                            <div class="row">
-                                <div class="col-xs-offset-1 col-xs-10">
-                                    <p class="text-center"><em>{{description}}</em></p>
-                                    <button class="btn btn-default btn-block">Read more</button>
-                                </div>
-                            </div>
-                        </a>
-                    </div>
+            {{#each yearlyUpdates}}
+                <div class="col-xs-12">
+                    <h2>What's new in {{year}}?</h2>
                 </div>
+                {{#each monthlyUpdates as |monthlyUpdate id|}}
+                    <div class="col-xs-12 col-sm-6 col-md-4">
+                        <div class="persona">
+                            <a href="{{id}}.html">
+                                <img class="img-responsive center-block" src="../img/{{img}}"/>
+                                <h3 class="text-center">{{title}}</h3>
+                                <div class="row">
+                                    <div class="col-xs-offset-1 col-xs-10">
+                                        <p class="text-center"><em>{{description}}</em></p>
+                                        <button class="btn btn-default btn-block">Read more</button>
+                                    </div>
+                                </div>
+                            </a>
+                        </div>
+                    </div>
+                {{/each}}
             {{/each}}
         </div>
     </div>

--- a/src/monthly-updates-index.handlebars
+++ b/src/monthly-updates-index.handlebars
@@ -24,24 +24,22 @@
         </div>
         <div class="row">
             {{#each yearlyUpdates}}
-                <div class="col-xs-12">
-                    <h2>What's new in {{year}}?</h2>
+                <div class="col-xs-2 col-md-1">
+                    <h1>{{year}}</h1>
+                </div>
+                <div class="col-xs-10 col-md-11">
+                    <hr style="margin: 90px 0 32px 0;"></hr>
                 </div>
                 {{#each monthlyUpdates as |monthlyUpdate id|}}
-                    <div class="col-xs-12 col-sm-6 col-md-4">
-                        <div class="persona">
-                            <a href="{{id}}.html">
-                                <img class="img-responsive center-block" src="../img/{{img}}"/>
-                                <h3 class="text-center">{{title}}</h3>
-                                <div class="row">
-                                    <div class="col-xs-offset-1 col-xs-10">
-                                        <p class="text-center"><em>{{description}}</em></p>
-                                        <button class="btn btn-default btn-block">Read more</button>
-                                    </div>
-                                </div>
-                            </a>
-                        </div>
+                    <div class="col-xs-5 col-md-4 col-lg-3">
+                        <img class="img-responsive center-block" src="../img/{{img}}" style="margin-top: 50px;"/>
                     </div>
+                    <div class="col-xs-12 col-sm-7 col-md-8 col-lg-9">
+                        <h3>{{title}}</h3>
+                        <p><em>{{description}}</em></p>
+                        <a href="{{id}}.html" class="btn btn-primary btn-ghost btn-sm" style="margin-bottom: 20px;">Read more</a>
+                    </div>
+                <div class="col-xs-12"></div>
                 {{/each}}
             {{/each}}
         </div>

--- a/tasks/build-monthly-updates-as-html.js
+++ b/tasks/build-monthly-updates-as-html.js
@@ -81,6 +81,7 @@ function generateIndex(fileDirectorySource, fileDirectoryDestination, generateAl
         return keepUpdatesFromPreviousMonths(folderName, generateAllUpdates);
     });
 
+    // Classify all monthly updates by year
     var yearlyUpdates = [];
     _.each(monthlyUpdates, function(update, key) {
         var year = key.substring(0,4);
@@ -91,7 +92,6 @@ function generateIndex(fileDirectorySource, fileDirectoryDestination, generateAl
         yearlyUpdate = _.find(yearlyUpdates, ['year', year]);
         yearlyUpdate.monthlyUpdates[key] = update;
     });
-    console.log(yearlyUpdates);
 
     return gulp.src('src/monthly-updates-index.handlebars')
         .pipe(gulpHandlebars({

--- a/tasks/build-monthly-updates-as-html.js
+++ b/tasks/build-monthly-updates-as-html.js
@@ -81,10 +81,22 @@ function generateIndex(fileDirectorySource, fileDirectoryDestination, generateAl
         return keepUpdatesFromPreviousMonths(folderName, generateAllUpdates);
     });
 
+    var yearlyUpdates = [];
+    _.each(monthlyUpdates, function(update, key) {
+        var year = key.substring(0,4);
+        var yearlyUpdate = _.find(yearlyUpdates, ['year', year]);
+        if(!yearlyUpdate){
+            yearlyUpdates.push({'year':year, 'monthlyUpdates': {}});
+        }
+        yearlyUpdate = _.find(yearlyUpdates, ['year', year]);
+        yearlyUpdate.monthlyUpdates[key] = update;
+    });
+    console.log(yearlyUpdates);
+
     return gulp.src('src/monthly-updates-index.handlebars')
         .pipe(gulpHandlebars({
             title: 'What\'s new in Serenity',
-            monthlyUpdates: monthlyUpdates,
+            yearlyUpdates: yearlyUpdates,
             majorVersion: majorVersion
         }, {
             partialsDirectory: ['./src/partials']


### PR DESCRIPTION
To be able to know to which year a monthly update is linked.

A rework of the index page layout was necessary to make it more scalable over time.