### PR TITLE
Fix broken xs navigation opening

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
     "bootstrap": "3.4.1",
     "docsearch.js": "2.4.1",
     "isotope-layout": "^3.0.6",
-    "jquery": "3.5.0",
+    "jquery": "3.5.1",
     "lato-font": "3.0.0",
     "lodash": "^4.17.19",
     "typeface-comfortaa": "0.0.35"

--- a/src/partials/navbar-with-search.handlebars
+++ b/src/partials/navbar-with-search.handlebars
@@ -14,7 +14,7 @@
 
         <div class="collapse navbar-collapse" id="navbar-collapse">
             <form class="navbar-form navbar-left">
-                <div class="form-group form-search">
+                <div class="form-group form-search hidden-sm">
                     <input id="docSearch-input" type="text" class="form-control" placeholder="Search for PIM help...">
                 </div>
             </form>

--- a/styles/nav.less
+++ b/styles/nav.less
@@ -36,6 +36,7 @@ nav{
                 right: unset;
                 left: 15px;
             }
+            .box-shadow(0 10px 10px 0 @gray-light);
         }
         .navbar-nav {
             margin-top: 0;

--- a/tests/updates/nominal_case/expected_2020-02.html
+++ b/tests/updates/nominal_case/expected_2020-02.html
@@ -48,7 +48,7 @@
         
                 <div class="collapse navbar-collapse" id="navbar-collapse">
                     <form class="navbar-form navbar-left">
-                        <div class="form-group form-search">
+                        <div class="form-group form-search hidden-sm">
                             <input id="docSearch-input" type="text" class="form-control" placeholder="Search for PIM help...">
                         </div>
                     </form>

--- a/tests/updates/nominal_case/expected_index.html
+++ b/tests/updates/nominal_case/expected_index.html
@@ -48,7 +48,7 @@
         
                 <div class="collapse navbar-collapse" id="navbar-collapse">
                     <form class="navbar-form navbar-left">
-                        <div class="form-group form-search">
+                        <div class="form-group form-search hidden-sm">
                             <input id="docSearch-input" type="text" class="form-control" placeholder="Search for PIM help...">
                         </div>
                     </form>

--- a/yarn.lock
+++ b/yarn.lock
@@ -4609,10 +4609,10 @@ jest-worker@^26.3.0:
     merge-stream "^2.0.0"
     supports-color "^7.0.0"
 
-jquery@3.5.0:
-  version "3.5.0"
-  resolved "https://registry.yarnpkg.com/jquery/-/jquery-3.5.0.tgz#9980b97d9e4194611c36530e7dc46a58d7340fc9"
-  integrity sha512-Xb7SVYMvygPxbFMpTFQiHh1J7HClEaThguL15N/Gg37Lri/qKyhRGZYzHRyLH8Stq3Aow0LsHO2O2ci86fCrNQ==
+jquery@3.5.1:
+  version "3.5.1"
+  resolved "https://registry.yarnpkg.com/jquery/-/jquery-3.5.1.tgz#d7b4d08e1bfdb86ad2f1a3d039ea17304717abb5"
+  integrity sha512-XwIBPqcMn57FxfT+Go5pzySnm4KWkT1Tv7gjrpT1srtf8Weynl6R273VJ5GjkRb51IzMp5nbaPjJXMWeju2MKg==
 
 js-tokens@^4.0.0:
   version "4.0.0"


### PR DESCRIPTION
An update of jquery broke the opening of the xs navigation menu. Bumping the jquery's version to the next solves the issue.
I also added for better UX:
- a shadow under the menu,
- when the menu is displayed on small screens, on some pages.