### PR TITLE
1000 products deletion

### DIFF
--- a/content/md/products-super-power/product-mass-actions.md
+++ b/content/md/products-super-power/product-mass-actions.md
@@ -271,10 +271,6 @@ To delete multiple products:
 ![Confirm delete](../img/Products_BulkActionUppermenuDelete2.png)
 
 :::info
-Due to safety reasons, **you cannot remove more than 1000 products at a time.**
-:::
-
-:::info
 You can also mass delete [product models](what-about-products-variants.html#what-is-a-product-model). **If you delete product models, all their children (product models and variant products) are also deleted.**
 :::
 


### PR DESCRIPTION
Get rid of the info block, following discussion on this thread: https://akeneo.slack.com/archives/C352L4091/p1629996112019700.

We no more have to tell users not to delete more than 1,000 products in one time.