### PR TITLE
Fix deployment

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,4 +2,4 @@ FROM node:10-alpine
 RUN apk add yarn
 RUN apk add openssh-client
 RUN apk add rsync
-RUN npm install -g firebase-tools
+RUN npm install -g firebase-tools@v9


### PR DESCRIPTION
Firebase v10 does not work with node 10. Node 12 is required. Quickfix is to specify the major version.