### PR TITLE
Enrich workflow doc for bulk actions on draft

### DIFF
--- a/content/md/products-super-power/product-mass-actions.md
+++ b/content/md/products-super-power/product-mass-actions.md
@@ -96,6 +96,8 @@ These actions will not apply on products without families.
 
 :::ee
 A check box `Send for approval` is displayed in the confirmation step. If you select it and have `Edit` rights on products, you will automatically send the [drafts](proposals-workflow.html#statuses-of-products) for approval. At the end of the process, you will receive a notification with the number of proposals generated.
+
+If you have `Edit` rights on products and you use a bulk action to edit attributes values, then all changes made before on attributes on the [drafts](proposals-workflow.html#statuses-of-products) will be deleted after the mass action.
 :::
 
 ## Edit attribute values


### PR DESCRIPTION
Mention on the doc that a bulk actions on draft won't keep previous changes made on the drafts. 
https://help.akeneo.com/pim/serenity/articles/product-mass-actions.html#edit-attribute-values-or-add-new-attribute-values