### PR TITLE
Fix v6 menu

### DIFF
--- a/src/partials/version-navigation.handlebars
+++ b/src/partials/version-navigation.handlebars
@@ -1,5 +1,5 @@
 <div class="nav navbar-nav navbar-right">
-    <li class="active">
+    <li>
         <a href="/pim/serenity/index.html">Serenity EE/GE</a>
     </li>
     <li id="last-EE-version" data-filepath="{{filePath}}" data-current-doc-version="{{majorVersion}}"></li>


### PR DESCRIPTION
Instead of having this:
![Screenshot 2022-03-24 at 10 57 36](https://user-images.githubusercontent.com/25225430/159891193-f8735ead-e249-46e5-bd7c-5d8547c21604.png)

you will have that:
![Screenshot 2022-03-24 at 10 57 28](https://user-images.githubusercontent.com/25225430/159891246-60c8d73a-37af-4533-99c9-71412f5e39c1.png)