### PR TITLE
Table attribute for v6 in Help Center 

### DIFF
--- a/content/md/first-steps/manage-multidimensional-data-in-a-table.md
+++ b/content/md/first-steps/manage-multidimensional-data-in-a-table.md
@@ -11,7 +11,7 @@ related: manage-your-attributes
 # Overview
 
 Sometimes, it can be useful to present product information in a table, in order to **ease the enrichment**, **improve the readability** of the product sheet, and/or because it is **required by law** (for instance, to present the nutritional values of a product in the food industry).
-s
+
 This is why we've decided to create a new attribute type: the **Table attribute**.
 
 :::info

--- a/content/md/first-steps/manage-multidimensional-data-in-a-table.md
+++ b/content/md/first-steps/manage-multidimensional-data-in-a-table.md
@@ -11,7 +11,7 @@ related: manage-your-attributes
 # Overview
 
 Sometimes, it can be useful to present product information in a table, in order to **ease the enrichment**, **improve the readability** of the product sheet, and/or because it is **required by law** (for instance, to present the nutritional values of a product in the food industry).
-
+s
 This is why we've decided to create a new attribute type: the **Table attribute**.
 
 :::info
@@ -56,18 +56,16 @@ Each column is defined by a `code`, a `label`, and a `type`. The label can be tr
 ### Once the table structure is defined and saved, it cannot be changed afterward.
 It means that your columns are frozen once you've clicked on `Save`. If you need to change the code or the type of a column, you must delete and re-create it.
 
-### The first column is always a `Select` or a `Reference entity` one.
-To structure your table, you can choose among 6 column types:
+### The first column is always a `Select` one.
+To structure your table, you can choose among 4 column types:
 - `Select`
 - `Yes/No`(boolean)
 - `Number`
 - `Text`
-- `Reference entity` (EE only)
-- `Measurement`
 
-Nevertheless, **the first column type must always be `Select`** or a `Reference entity` one.  
+Nevertheless, **the first column type must always be a `Select`** one.  
 
-We will detail how these 6 column types work in the [next section](#specificity-of-each-column-type).
+We will detail how these 4 column types work in the [next section](#specificity-of-each-column-type).
 
 ## Specificity of each column type
 
@@ -102,19 +100,6 @@ In the `Number` column type, you can specify the `minimum value`, the `maximum v
 ### Yes/No (boolean) column type
 There is no validation parameters in this column type!
 
-### Reference entity column type (EE only)
-If you already use the reference entity feature to handle your ingredients, materials, or colors as records you can easily use them in your table attribute. To do so, you just have to select the `reference entity` column type and choose the reference entity to link, in order to get all the existing records as options.
-
-:::info
-It's impossible to create records from a table attribute.
-:::
-
-### Measurement column type
-In the `Measurement` column type, you will first be asked to choose the `Measurement family` your column will inherit from. Then, you will be able to define the `Default unit`.
-
-:::info
-Note that the `Measurement family` cannot be changed once the column has been saved but the `Default unit` can.
-:::
 
 ## Scalability of a table attribute
 In order to ensure that the PIM keeps running, we have defined some limits.  


### PR DESCRIPTION
Modifying v6 version of the table attribute article as reference entities & measurement are not available columns in v6 compared to Serenity