### PR TITLE
Correct Configure the SP section of the SSO

### DIFF
--- a/content/md/user-management/configure-saml-sso.md
+++ b/content/md/user-management/configure-saml-sso.md
@@ -98,7 +98,7 @@ The `Metadata URL` and `ACS URL` are read-only. They have a built-in 'copy' func
 :::
 
 :::info
-The SP certificate is self-signed and is generated to never expire. You will never have to renew it.
+The SP certificate is self-signed by default. The expiration date is visible from the UI. Once expired, you will have to renew it.
 :::
 
 # Disable the SSO


### PR DESCRIPTION
Correct https://help.akeneo.com/pim/v6/articles/configure-saml-sso.html#configure-the-sso page because the documentation informed that "The SP certificate ...is generated to never expire. You will never have to renew it." while it expires after 1 year-period, visible in the UI (today). So the idea is to correct and replace with correct info: The SP certificate is self-signed by default. The expiration date is visible from the UI. Once expired, you will have to renew it."