### PR TITLE
Remove simple reference data attribute

### DIFF
--- a/content/md/first-steps/manage-families.md
+++ b/content/md/first-steps/manage-families.md
@@ -245,7 +245,6 @@ You can create one or more family variants in each family.
 ::: info
 An attribute of the family could be a **variant axis** only if its attribute type is **structured**:
 - **Simple select**
-- **Simple reference data**
 - **Reference entity single link** _(EE only)_
 - [**Measurement**](what-about-measurements.html)
 - **Boolean (Yes/No)**       


### PR DESCRIPTION
Simple reference data attributes doesn't exist anymore in master/v7 https://help.akeneo.com/pim/serenity/articles/manage-your-families.html#create-a-new-family-variant