### PR TITLE
PIM-10705: Revert time limit for asset preview generation

### DIFF
--- a/content/md/assets/create-and-display-assets.md
+++ b/content/md/assets/create-and-display-assets.md
@@ -218,5 +218,4 @@ If you want to be sure that the thumbnail that you are currently seeing is still
 To optimize user experience, we set three limits to get a preview:  
 * 56 MB for the size of an asset
 * 2 seconds to fetch an asset from its distant server
-* 60 seconds to generate the preview
 :::


### PR DESCRIPTION
We reverted the 60s limit for asset preview generation.
see https://github.com/akeneo/pim-enterprise-dev/pull/15439