### PR TITLE
Update category ACLs for EC Early Access

### DIFF
--- a/content/md/permissions-settings/manage-the-interface-and-actions-accesses.md
+++ b/content/md/permissions-settings/manage-the-interface-and-actions-accesses.md
@@ -184,11 +184,9 @@ It is possible to import and export these permissions by using the dedicated imp
 |---------------------------|--------------|
 | Create a category                | User can create a new category while clicking on the tree and click on the  `Create a new category` button in the `Settings`/`Categories` menu entry |
 | Edit a category                  | User can edit a category while directly clicking on the category line. It allows to access the `Properties` tab to edit and save the category’s label translations. |
-| View category history | User can access the `History` tab of categories to view categories’ history at the condition that Edit a category right has been activated.
- |
+| View category history | User can access the `History` tab of categories to view categories’ history at the condition that Edit a category right has been activated.|
 | List categories | User can see and access all trees, then any of their related categories and sub-categories listed under the `Settings`/`Categories` menu entry |
-| Order/reorder categories         | In a category tree, user can order/reorder categories in the list using the drag-and-drop capacity at the condition that List categories right has been activated. Info: if you already have the right of Edit a category, the new Order/reorder categories right will be automatically activated.
- |
+| Order/reorder categories         | In a category tree, user can order/reorder categories in the list using the drag-and-drop capacity at the condition that List categories right has been activated. Info: if you already have the right of Edit a category, the new Order/reorder categories right will be automatically activated.|
 | Remove a category | User can remove a category using the `Delete` button |
 | Manage category template | User can `Activate` a category template per tree and `View` its related attributes in the new `Attributes` tab. Activating a category template is a prerequisite to `Edit category attributes`, allowing the user to enrich a category with content. Info: if you already have the right of Create a category or Edit a category, the new Manage category template right will be automatically activated. |
 | Edit category attributes | Once a category template has been activated for a given category tree, user can access the edition of the category attributes through the `Attributes` tab of any of its categories, at the condition that Edit categories has been activated. Info: if you already have the right of Edit a category, the new Edit category attributes right will be automatically activated. |

--- a/content/md/permissions-settings/manage-the-interface-and-actions-accesses.md
+++ b/content/md/permissions-settings/manage-the-interface-and-actions-accesses.md
@@ -182,12 +182,17 @@ It is possible to import and export these permissions by using the dedicated imp
 
 | Permission name | Effect on the interface |
 |---------------------------|--------------|
-| Create a category                | User can create a new category with a right click on the tree and click on the  `Create a new category` button in the `Settings`/`Categories` menu entry |
-| Edit a category                  | User can edit a category |
-| View category history | User can access the `History` tab of categories |
-| List categories | User can see and access all categories and category trees listed under the `Settings`/`Categories` menu entry |
+| Create a category                | User can create a new category while clicking on the tree and click on the  `Create a new category` button in the `Settings`/`Categories` menu entry |
+| Edit a category                  | User can edit a category while directly clicking on the category line. It allows to access the `Properties` tab to edit and save the category’s label translations. |
+| View category history | User can access the `History` tab of categories to view categories’ history at the condition that Edit a category right has been activated.
+ |
+| List categories | User can see and access all trees, then any of their related categories and sub-categories listed under the `Settings`/`Categories` menu entry |
+| Order/reorder categories         | In a category tree, user can order/reorder categories in the list using the drag-and-drop capacity at the condition that List categories right has been activated. Info: if you already have the right of Edit a category, the new Order/reorder categories right will be automatically activated.
+ |
 | Remove a category | User can remove a category using the `Delete` button |
-| Manage category permissions _(EE only)_ | User has access to the `Permissions` tab on a category |
+| Manage category template | User can `Activate` a category template per tree and `View` its related attributes in the new `Attributes` tab. Activating a category template is a prerequisite to `Edit category attributes`, allowing the user to enrich a category with content. Info: if you already have the right of Create a category or Edit a category, the new Manage category template right will be automatically activated. |
+| Edit category attributes | Once a category template has been activated for a given category tree, user can access the edition of the category attributes through the `Attributes` tab of any of its categories, at the condition that Edit categories has been activated. Info: if you already have the right of Edit a category, the new Edit category attributes right will be automatically activated. |
+| Manage category permissions _(EE only)_ | User can access the `Permissions` tab on a category, at the condition that Edit a category right has been activated. User can handle which user groups are allowed to view, edit and own products. Info: please note that even if you have defined specific access rights on product information, in order to configure a specific scope of role and visibility of users to the product catalog based upon the categories (“Allowed to view/edit/own products”), every user group will be able to activate a category template and edit category attributes as soon as the permissions detailed in the Manage category template and Edit category attributes sections above have been activated. |
 
 ## Permissions on channels
 


### PR DESCRIPTION
As we will soon deliver EC Early Access in SaaS only (not v7), I need to update and add new specific ACLs to the article named "Manage the interface and actions accesses" in the  Permissions on categories section.  The merge will be only done after Master production branch is unfrozen and feature flag activated to release the feature.