### PR TITLE
Release official flexv7

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -55,14 +55,18 @@ workflows:
 
     deployment:
         jobs:
-            - deploy_staging
+            - approve_to_deploy_staging:
+                type: approval
+            - deploy_staging:
+                requires:
+                    - approve_to_deploy_staging
             - approve_to_deploy_in_production:
-                  type: approval
-                  filters:
-                      branches:
-                          only: v7
-                  requires:
-                      - deploy_staging
+                type: approval
+                filters:
+                    branches:
+                        only: v7
+                requires:
+                    - deploy_staging
 
             - deploy_production:
                   requires:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -55,13 +55,12 @@ workflows:
 
     deployment:
         jobs:
-            - deploy_staging:
+            - deploy_staging
+            - approve_to_deploy_in_production:
+                  type: approval
                   filters:
                       branches:
                           only: v7
-
-            - approve_to_deploy_in_production:
-                  type: approval
                   requires:
                       - deploy_staging
 

--- a/Makefile
+++ b/Makefile
@@ -22,5 +22,5 @@ build: yarn-install
 	 $(DOCKER_RUN) -e HELP_CENTER_URL=$(HELP_CENTER_URL) -e ONLY_PREVIOUS_MONTH_UPDATES=$(ONLY_PREVIOUS_MONTH_UPDATES) $(DOCKER_IMAGE_TAG) yarn gulp create-dist
 
 deploy: build
-	$(DOCKER_RUN) -v /etc/passwd:/etc/passwd:ro -v $${SSH_AUTH_SOCK}:/ssh-auth.sock:ro -e SSH_AUTH_SOCK=/ssh-auth.sock $(DOCKER_IMAGE_TAG) rsync --no-v -e "ssh -q -p $${PORT} -o StrictHostKeyChecking=no" -az --delete dist/pim/v7/ akeneo@$${HOSTNAME}:/var/www/html/pim/v7
+	$(DOCKER_RUN) -v /etc/passwd:/etc/passwd:ro -v $${SSH_AUTH_SOCK}:/ssh-auth.sock:ro -e SSH_AUTH_SOCK=/ssh-auth.sock $(DOCKER_IMAGE_TAG) rsync --no-v -e "ssh -q -p $${PORT} -o StrictHostKeyChecking=no" -az --delete dist/pim/flexibility-v7/ akeneo@$${HOSTNAME}:/var/www/html/pim/flexibility-v7
 	$(DOCKER_RUN) -v /etc/passwd:/etc/passwd:ro -v $${SSH_AUTH_SOCK}:/ssh-auth.sock:ro -e SSH_AUTH_SOCK=/ssh-auth.sock $(DOCKER_IMAGE_TAG) rsync --no-v -e "ssh -q -p $${PORT} -o StrictHostKeyChecking=no" -az dist/pim/versions.json akeneo@$${HOSTNAME}:/var/www/html/pim/versions.json

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -33,7 +33,7 @@ gulp.task('launch-webserver', ['create-dist'], function() {
     .pipe(webserver({
       livereload: true,
       directoryListing: false,
-      open: '/pim/v7/',
+      open: '/pim/flexibility-v7/',
       host: '0.0.0.0',
     }));
 });

--- a/src/index.handlebars
+++ b/src/index.handlebars
@@ -119,13 +119,13 @@
             <a href="https://www.akeneo.com/customers-stories/?source=akeneo-help"><p>Customer stories ></p></a>
         </div>
         <div class="col-xs-6 col-sm-4">
-            <a href="/pim/v7/updates/index.html"><p>What's new in Serenity? ></p></a>
+            <a href="/pim/flexibility-v7/updates/index.html"><p>What's new in Serenity? ></p></a>
         </div>
         <div class="col-xs-6 col-sm-4">
-            <a href="/pim/v7/supported-versions-table.html"><p>Product support dates ></p></a>
+            <a href="/pim/flexibility-v7/supported-versions-table.html"><p>Product support dates ></p></a>
         </div>
         <div class="col-xs-6 col-sm-4">
-            <a href="/pim/v7/whats-next.html"><p>What's coming next in Serenity? ></p></a>
+            <a href="/pim/flexibility-v7/whats-next.html"><p>What's coming next in Serenity? ></p></a>
         </div>
     </div>
 </div>

--- a/src/partials/layout.handlebars
+++ b/src/partials/layout.handlebars
@@ -43,7 +43,6 @@
 </script>
 
 <body data-spy="scroll" data-target="#navbar">
-    <div style="position: sticky; top: 60px; z-index: 1; background: #FCCE76; margin-top: 0px; padding: 15px;">This version is currently in beta, official release is 8 March 2023</div>
     <div id="mainContent">
         {{> @partial-block }}
     </div>

--- a/src/versions-in-detail.handlebars
+++ b/src/versions-in-detail.handlebars
@@ -40,7 +40,7 @@
                         <p>With this version, <b>each month</b>, benefit from new and exclusive features.<br>And no need to worry about migrations! Those new features are automatically delivered in your PIM.</p>
                         <div class="row">
                             <div class="col-xs-12">
-                                <a href="/pim/v7/updates/index.html" class="btn btn-primary btn-ghost btn-sm">Discover our latest monthly updates</a>
+                                <a href="/pim/flexibility-v7/updates/index.html" class="btn btn-primary btn-ghost btn-sm">Discover our latest monthly updates</a>
                             </div>
                         </div>
                         <h3>Exclusive features</h3>
@@ -64,7 +64,7 @@
                                 </div>
                             {{/each}}
                             <div class="col-xs-12">
-                                <a href="/pim/v7/whats-new.html" class="btn btn-primary btn-sm btn-ghost">Check out all the other exclusive features</a>
+                                <a href="/pim/flexibility-v7/whats-new.html" class="btn btn-primary btn-sm btn-ghost">Check out all the other exclusive features</a>
                             </div>
                         </div>
                     </div>

--- a/src/versions.json
+++ b/src/versions.json
@@ -1,7 +1,7 @@
 [
   {
-    "url": "/pim/v7/",
-    "version": "v7",
+    "url": "/pim/flexibility-v7/",
+    "version": "flexibility-v7",
     "label": "7.0 EE Flexibility/CE",
     "suffix_with_filename": true
   },

--- a/tasks/build-articles.js
+++ b/tasks/build-articles.js
@@ -19,7 +19,7 @@ const rename = require('gulp-rename');
 const revReplace = require('gulp-rev-replace');
 const HelpcenterMarkdownIt = require('./common/markdown-it.js');
 
-var majorVersion = 'v7';
+var majorVersion = 'flexibility-v7';
 
 
 gulp.task('build-articles', ['clean-dist','less', 'build-themes'], function () {

--- a/tasks/build-themes.js
+++ b/tasks/build-themes.js
@@ -11,7 +11,7 @@ var frontMatter = require('gulp-front-matter');
 var rename = require('gulp-rename');
 var revReplace = require('gulp-rev-replace');
 
-var majorVersion = 'v7';
+var majorVersion = 'flexibility-v7';
 
 gulp.task('build-themes', ['clean-dist','less'], function () {
     // For each Json file containing the Persona themes

--- a/tasks/build-updates-as-html.js
+++ b/tasks/build-updates-as-html.js
@@ -30,7 +30,7 @@ function sort(comparator) {
     });
 }
 
-const majorVersion = 'v7';
+const majorVersion = 'flexibility-v7';
 
 module.exports = {generateIndex};
 
@@ -76,7 +76,7 @@ md
 
 gulp.task('build-updates-as-html', ['clean-dist','less'], function() {
     const fileDirectorySource = 'content/updates';
-    const fileDirectoryDestination = './dist/pim/v7/updates';
+    const fileDirectoryDestination = './dist/pim/' + majorVersion + '/updates';
 
     return generateIndex(fileDirectorySource, fileDirectoryDestination);
 });

--- a/tasks/copy-assets.js
+++ b/tasks/copy-assets.js
@@ -5,7 +5,7 @@ var gulp = require('gulp');
 var rename = require('gulp-rename');
 var merge = require('merge-stream');
 
-var majorVersion = 'v7';
+var majorVersion = 'flexibility-v7';
 
 gulp.task('copy-assets', ['clean-dist'], function(){
     var lib = gulp.src([

--- a/tasks/landings.js
+++ b/tasks/landings.js
@@ -12,7 +12,7 @@ var revReplace = require('gulp-rev-replace');
 var tap = require('gulp-tap');
 var frontMatter = require('gulp-front-matter');
 
-var majorVersion = 'v7';
+var majorVersion = 'flexibility-v7';
 
 // This task goes through every Markdown articles looking for "popular" articles
 // in order to find information such as their title and path.

--- a/tasks/less.js
+++ b/tasks/less.js
@@ -6,7 +6,7 @@ var less = require('gulp-less');
 var path = require('path');
 var rev = require('gulp-rev');
 
-var majorVersion = 'v7';
+var majorVersion = 'flexibility-v7';
 
 gulp.task('less', ['clean-dist'], function () {
     return gulp.src('./styles/variables.less')

--- a/tests/updates/nominal_case/expected_2020-02.html
+++ b/tests/updates/nominal_case/expected_2020-02.html
@@ -43,7 +43,6 @@
 </script>
 
 <body data-spy="scroll" data-target="#navbar">
-    <div style="position: sticky; top: 60px; z-index: 1; background: #FCCE76; margin-top: 0px; padding: 15px;">This version is currently in beta, official release is 8 March 2023</div>
     <div id="mainContent">
         <nav class="navbar navbar-default navbar-fixed-top">
             <div class="container-fluid">


### PR DESCRIPTION
In this PR, 

- I changed the url used for v7 version. Now the documentation is available here: https://help-staging.akeneo.com/pim/flexibility-v7/. By doing it we want to improve your SEO
- I removed the announcement banner
- I added the possibility to deploy a staging environment from all branches (production is always restricted to v7)