### PR TITLE
Fix flexibility-v7x path in master

### DIFF
--- a/src/versions.json
+++ b/src/versions.json
@@ -1,7 +1,7 @@
 [
   {
-    "url": "/pim/v7/",
-    "version": "v7",
+    "url": "/pim/flexibility-v7/",
+    "version": "flexibility-v7",
     "label": "7.0 EE Flexibility/CE",
     "suffix_with_filename": true
   },


### PR DESCRIPTION
In this PR: https://github.com/akeneo/pim-helpcenter/pull/1316 we changed the url used for the v7 documentation, in this PR I reported the change in order to have the right path when master will be deployed